### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 A Model Context Protocol (MCP) server for interacting with the Haloscan SEO API.  
 This server allows easy integration with Claude for Desktop, N8N, and other MCP-compatible clients.
 
-
+<a href="https://glama.ai/mcp/servers/@chouayb123/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@chouayb123/mcp/badge" alt="Haloscan Server MCP server" />
+</a>
 
 ## Features
 


### PR DESCRIPTION
This PR adds a badge for the [Haloscan MCP Server](https://glama.ai/mcp/servers/@chouayb123/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@chouayb123/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@chouayb123/mcp/badge" alt="Haloscan Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.